### PR TITLE
Fix release workflow to find assets in the correct place

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
           "build/Build/Products/Release/MemStat.app" \
           "MemStat-${{ github.event.inputs.version || github.ref_name }}.zip"
     
+    - name: List artifacts
+      run: ls -la dist/ || true
+    
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
@@ -93,8 +96,7 @@ jobs:
         draft: false
         prerelease: false
         files: |
-          MemStat-*.dmg
-          MemStat-*.zip
+          dist/*.dmg
+          dist/*.zip
         generate_release_notes: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary by Sourcery

Fix the GitHub Actions release workflow to correctly include assets from the dist directory when creating a release

CI:
- Add a step to list the contents of the dist directory for debugging
- Update release file globs to use dist/*.dmg and dist/*.zip
- Remove redundant GITHUB_TOKEN environment variable from the release step